### PR TITLE
feat: Add Heat/Cold sources and fix element dropdown

### DIFF
--- a/compounds.json
+++ b/compounds.json
@@ -7,6 +7,22 @@
         "temperature": -273,
         "density_proxy": 0
     },
+    "HEAT": {
+        "symbol": "HEAT",
+        "name": "Heat Source",
+        "color": "#FF4500",
+        "phase_at_stp": "Solid",
+        "temperature": 1000,
+        "density_proxy": 10
+    },
+    "COLD": {
+        "symbol": "COLD",
+        "name": "Cold Source",
+        "color": "#00BFFF",
+        "phase_at_stp": "Solid",
+        "temperature": -100,
+        "density_proxy": 10
+    },
     "FIRE": {
         "symbol": "FIRE",
         "name": "Fire",

--- a/script.js
+++ b/script.js
@@ -341,20 +341,45 @@ document.addEventListener('DOMContentLoaded', () => {
         requestAnimationFrame(render);
     }
     
-    /** Populates the dropdown with pure periodic table elements only */
+    /** Populates the dropdown with categorized elements and compounds */
     function populateElementSelector() {
         elementSelector.innerHTML = '';
-        Object.keys(elements)
-            .filter(symbol =>
-                elements[symbol].atomic_number !== undefined
-            )
-            .sort((a, b) => elements[a].atomic_number - elements[b].atomic_number)
-            .forEach(symbol => {
-                const option = document.createElement('option');
-                option.value = symbol;
-                option.textContent = elements[symbol].name || symbol;
-                elementSelector.appendChild(option);
-            });
+
+        // --- Create Option Groups ---
+        const elementGroup = document.createElement('optgroup');
+        elementGroup.label = 'Elements';
+
+        const specialGroup = document.createElement('optgroup');
+        specialGroup.label = 'Special';
+
+        // --- Filter and Sort ---
+        const periodicElements = Object.keys(elements)
+            .filter(symbol => elements[symbol].atomic_number !== undefined)
+            .sort((a, b) => elements[a].atomic_number - elements[b].atomic_number);
+
+        const specialElements = Object.keys(elements)
+            .filter(symbol => elements[symbol].atomic_number === undefined)
+            .sort((a,b) => (elements[a].name || a).localeCompare(elements[b].name || b));
+
+
+        // --- Populate Groups ---
+        periodicElements.forEach(symbol => {
+            const option = document.createElement('option');
+            option.value = symbol;
+            option.textContent = elements[symbol].name || symbol;
+            elementGroup.appendChild(option);
+        });
+
+        specialElements.forEach(symbol => {
+            const option = document.createElement('option');
+            option.value = symbol;
+            option.textContent = elements[symbol].name || symbol;
+            specialGroup.appendChild(option);
+        });
+
+        elementSelector.appendChild(elementGroup);
+        elementSelector.appendChild(specialGroup);
+
         elementSelector.value = currentElement;
     }
 


### PR DESCRIPTION
This commit introduces two main changes:

1.  Adds 'HEAT' and 'COLD' as special, paintable sources in `compounds.json`. These will affect the temperature of particles that pass through them.

2.  Refactors the element selector in `script.js` to correctly display all available elements and compounds. The dropdown is now categorized into 'Elements' (for periodic table elements) and 'Special' (for compounds and sources like Heat/Cold), which fixes the bug where only elements with an atomic number were shown.