### PR TITLE
feat: Implement hydrogen ionization and recombination

### DIFF
--- a/data/compounds.js
+++ b/data/compounds.js
@@ -146,5 +146,23 @@ const COMPOUNDS_DATA = {
         "is_sun": true,
         "heat_range": 50,
         "heat_intensity": 100
+    },
+    "Hplus": {
+        "symbol": "Hplus",
+        "name": "Hydrogen Ion (Proton)",
+        "color": "#FF4500",
+        "phase_at_stp": "Gas",
+        "temperature": 25,
+        "density_proxy": 0.0001,
+        "is_plasma": true
+    },
+    "eminus": {
+        "symbol": "eminus",
+        "name": "Electron",
+        "color": "#00BFFF",
+        "phase_at_stp": "Gas",
+        "temperature": 25,
+        "density_proxy": 0.00001,
+        "is_plasma": true
     }
 };

--- a/data/rules.js
+++ b/data/rules.js
@@ -122,5 +122,12 @@ const RULES_DATA = [
         "enabled": true,
         "is_magnetism": true,
         "probability": 0.5
+    },
+    {
+        "name": "Hydrogen Recombination (H+ + e-)",
+        "enabled": true,
+        "reactants": { "center": "Hplus", "neighbors": ["eminus"] },
+        "products": { "center": "H", "consumed_neighbors": 1 },
+        "probability": 0.8
     }
 ];


### PR DESCRIPTION
This commit introduces the simulation of hydrogen ionization into plasma.

- Defines `Hplus` (proton) and `eminus` (electron) as new compounds in `data/compounds.js`.
- Implements a temperature-driven ionization mechanism in `script.js` where hydrogen atoms (`H`) can ionize into `Hplus` and `eminus` above a certain temperature threshold.
- Adds a new rule to `data/rules.js` for the recombination of `Hplus` and `eminus` back into neutral hydrogen.
- The new logic is integrated into the main simulation loop.